### PR TITLE
Add 404 page with ja/en language detection

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 — ヘブライ語Alefbet道場</title>
+  <meta http-equiv="refresh" content="5;url=/">
+  <script>
+    var _lang = localStorage.getItem('alefbet-lang') === 'en' ? 'en' : 'ja';
+    if (_lang === 'en') document.documentElement.lang = 'en';
+    if (localStorage.getItem('hebrew-quiz-theme') === 'dark')
+      document.documentElement.setAttribute('data-theme', 'dark');
+  </script>
+  <link rel="stylesheet" href="subpage.css">
+  <style>
+    .not-found-body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 3rem 1rem;
+      gap: 1rem;
+    }
+    .not-found-char {
+      font-family: 'Cardo', serif;
+      font-size: 5rem;
+      line-height: 1;
+      color: #17B890;
+      margin-bottom: 0.5rem;
+    }
+    .not-found-code {
+      font-size: 1rem;
+      font-weight: 700;
+      color: var(--text-sub);
+      letter-spacing: 0.1em;
+    }
+    .not-found-title {
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: var(--text-heading);
+    }
+    .not-found-msg {
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+      line-height: 1.8;
+    }
+    .not-found-btn {
+      display: inline-block;
+      margin-top: 1rem;
+      padding: 0.85rem 2.5rem;
+      background: linear-gradient(135deg, #1de9b6 0%, #17B890 50%, #0d7a60 100%);
+      color: #fff;
+      font-size: 1rem;
+      font-weight: 700;
+      border-radius: 9999px;
+      text-decoration: none;
+      box-shadow: 0 4px 20px rgba(23, 184, 144, 0.35);
+      transition: opacity 0.15s;
+    }
+    .not-found-btn:hover { opacity: 0.9; text-decoration: none; color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="legal-wrap">
+    <header class="legal-header">
+      <a class="back-link" id="back-link" href="/"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg><span id="site-name">ヘブライ語Alefbet道場</span></a>
+      <button class="theme-toggle" id="theme-toggle" aria-label="ダークモード切替">
+        <svg class="theme-icon theme-icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg class="theme-icon theme-icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+      </button>
+    </header>
+
+    <main class="legal-card">
+      <div class="not-found-body">
+        <div class="not-found-char">אַיֵּה</div>
+        <div class="not-found-code">404</div>
+        <div class="not-found-title" id="not-found-title">ページが見つかりません</div>
+        <p class="not-found-msg" id="not-found-msg">お探しのページは存在しないか、移動した可能性があります。<br><span id="countdown">5</span><span id="countdown-suffix">秒後にトップページへ移動します。</span></p>
+        <a class="not-found-btn" href="/" id="not-found-btn">トップへ戻る</a>
+      </div>
+    </main>
+
+    <footer class="legal-footer">
+      <div>© 2026 Shingo Kumagai</div>
+    </footer>
+  </div>
+  <script>
+    (function() {
+      var lang = localStorage.getItem('alefbet-lang') === 'en' ? 'en' : 'ja';
+      if (lang === 'en') {
+        document.title = '404 — Hebrew Alefbet Dojo';
+        document.getElementById('site-name').textContent = 'Hebrew Alefbet Dojo';
+        document.getElementById('theme-toggle').setAttribute('aria-label', 'Toggle dark mode');
+        document.getElementById('not-found-title').textContent = 'Page Not Found';
+        document.getElementById('not-found-msg').innerHTML = 'The page you\'re looking for doesn\'t exist or may have moved.<br><span id="countdown">5</span><span id="countdown-suffix"> seconds until you\'re redirected to the top page.</span>';
+        document.getElementById('not-found-btn').textContent = 'Back to Top';
+      }
+    })();
+
+    var n = 5;
+    var el = document.getElementById('countdown');
+    setInterval(function() { if (el && n > 1) el.textContent = --n; }, 1000);
+
+    document.getElementById('theme-toggle').addEventListener('click', function() {
+      var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        document.documentElement.removeAttribute('data-theme');
+        localStorage.removeItem('hebrew-quiz-theme');
+      } else {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        localStorage.setItem('hebrew-quiz-theme', 'dark');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `404.html` served by GitHub Pages for all unmatched URLs
- Detects language via `localStorage` (`alefbet-lang`) and displays Japanese or English content accordingly
- Auto-redirects to `/` after 5 seconds with a countdown timer
- Hebrew word אַיֵּה (ayeh, "where?") used as the visual — appears in Job 14:10 in the context of mortality

## Test plan
- [ ] Visit a non-existent URL (e.g. `/foo`) → 404 page appears
- [ ] Countdown from 5 to 1, then redirects to top page
- [ ] With `alefbet-lang=en` in localStorage → English text shown
- [ ] With `alefbet-lang=ja` (or unset) → Japanese text shown
- [ ] Dark mode toggle works
- [ ] Back-link leads to `/`

Closes #30